### PR TITLE
Adds db.host example to build properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ The variables that Phing uses are configured at the top of build.xml. If there a
 
 ; The uri of the site.
 drupal.base_url='http://govcms.local/'
+
+; The database settings.
+; db.host=DB_HOST
+; db.name=DB_NAME
+; db.username=DB_USER
+; db.password=DB_PASS
+; db.port=DB_PORT
 ```
 
 If you are making changes to the make file, you can tell the build process to build from your local make file, instead of the one in the profile repository.

--- a/build/phing/example.build.properties
+++ b/build/phing/example.build.properties
@@ -5,6 +5,7 @@
 ; drupal.base_url='http://govcms.local/'
 
 ; The database settings.
+; db.host=DB_HOST
 ; db.name=DB_NAME
 ; db.username=DB_USER
 ; db.password=DB_PASS


### PR DESCRIPTION
Small addition to the example build properties file to assist docker/multitier users who have a db on a separate host.
