### PR TITLE
Make behat tests phantomjs compatible.

### DIFF
--- a/build/tests/behat/bootstrap/FeatureContext.php
+++ b/build/tests/behat/bootstrap/FeatureContext.php
@@ -123,14 +123,38 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
+   * Sets an id for the first iframe situated in the element specified by id.
+   * Needed when wanting to fill in WYSIWYG editor situated in an iframe without identifier.
+   *
+   * @Given /^the iframe in element "(?P<element>[^"]*)" has id "(?P<id>[^"]*)"$/
+   */
+  public function theIframeInElementHasId($element_id, $iframe_id) {
+    $function = <<<JS
+(function(){
+  var elem = document.getElementById("$element_id");
+  var iframes = elem.getElementsByTagName('iframe');
+  var f = iframes[0];
+  f.id = "$iframe_id";
+})()
+JS;
+    try {
+      $this->getSession()->executeScript($function);
+    }
+    catch(Exception $e) {
+      throw new \Exception(sprintf('No iframe found in the element "%s" on the page "%s".', $element_id, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
    * Fills in WYSIWYG editor with specified id.
    *
-   * @Given /^(?:|I )enter "(?P<text>[^"]*)" for WYSIWYG "(?P<iframe>[^"]*)"$/
+   * @Given /^(?:|I )fill in "(?P<text>[^"]*)" in WYSIWYG editor "(?P<iframe>[^"]*)"$/
    */
   public function iFillInInWYSIWYGEditor($text, $iframe) {
     try {
       $this->getSession()->switchToIFrame($iframe);
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       throw new \Exception(sprintf("No iframe with id '%s' found on the page '%s'.", $iframe, $this->getSession()->getCurrentUrl()));
     }
     $this->getSession()->executeScript("document.body.innerHTML = '<p>" . $text . "</p>'");

--- a/build/tests/behat/features/breadcrumbs.feature
+++ b/build/tests/behat/features/breadcrumbs.feature
@@ -4,13 +4,14 @@ Feature: Breadcrumbs
   As an user
   I can see breadcrumbs for the parent pages of the current page
 
-  @api
+  @api @javascript
   Scenario: Breadcrumbs are set for news items
     Given I am logged in as a user named "peta" with the "Content editor" role that doesn't force password change
     When I go to "/node/add/news-article"
-    Then the response status code should be 200
+    Then I should see "Create News Article"
     And I enter "test" for "Title"
-    And I enter "govCMS is the best!" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "Body text" in WYSIWYG editor "body-wysiwyg"
     And press "Save"
     Then I should see "News Article test has been created"
     Then the response should contain "<a href=\"/\">Home</a>"

--- a/build/tests/behat/features/chosen-tags.feature
+++ b/build/tests/behat/features/chosen-tags.feature
@@ -2,7 +2,7 @@ Feature: Chosen library applies to tags
 
   Users can use chosen to select tags
 
-  @api
+  @api @javascript
   Scenario: Chosen library is installed correctly
     Given I am logged in as a user named "stuart" with the "administrator" role that doesn't force password change
     And I go to "admin/reports/status"

--- a/build/tests/behat/features/home.feature
+++ b/build/tests/behat/features/home.feature
@@ -2,10 +2,10 @@ Feature: Home Page
 
   Ensure the home page content is available
 
+  @javascript
   Scenario: View the homepage content
     Given I am on the homepage
-    Then the response status code should be 200
-    And I should see "Publications"
+    Then I should see "Publications"
     And I should see "News & Media"
     And I should see "Contact"
     And I should see "View more news"

--- a/build/tests/behat/features/metatags.feature
+++ b/build/tests/behat/features/metatags.feature
@@ -4,33 +4,40 @@ Feature:Meta tags
   As an editor
   I can create content and provide metatags
 
-  @api
+  @api @javascript
   Scenario: Meta-tags are auto set
     Given I am logged in as a user named "peter" with the "Content editor" role that doesn't force password change
     When I go to "/node/add/page"
-    Then the response status code should be 200
+    Then I should see "Create Standard page"
     And I enter "test" for "Title"
-    And I enter "When tweetle beetles fight, its called a tweetle beetle battle." for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "When tweetle beetles fight, its called a tweetle beetle battle." in WYSIWYG editor "body-wysiwyg"
+    And I follow "Dublin Core"
+    And I follow "Dublin Core Type"
     And I enter "Text" for "edit-metatags-und-dctermstype-item-value"
     And press "Save"
     Then I should see "Standard page test has been created"
-    And the response should contain "<meta name=\"description\" content=\"When tweetle beetles fight, its called a tweetle beetle battle.\" />"
+    And the response should contain "<meta name=\"description\" content=\"When tweetle beetles fight, its called a tweetle beetle battle.\">"
     And the response should contain "<title>test | govCMS</title>"
-    And the response should contain "<meta name=\"dcterms.type\" content=\"Text\" />"
-    And the response should contain "<meta name=\"dcterms.title\" content=\"test\" />"
+    And the response should contain "<meta name=\"dcterms.type\" content=\"Text\">"
+    And the response should contain "<meta name=\"dcterms.title\" content=\"test\">"
 
-  @api
+  @api @javascript
   Scenario: Meta-tags can be edited
     Given I am logged in as a user named "paul" with the "Content editor" role that doesn't force password change
     When I go to "/node/add/page"
-    Then the response status code should be 200
+    Then I should see "Create Standard page"
     And I enter "test" for "Title"
-    And I enter "When tweetle beetles fight, its called a tweetle beetle battle." for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "When tweetle beetles fight, its called a tweetle beetle battle." in WYSIWYG editor "body-wysiwyg"
+    And I follow "Dublin Core"
+    And I follow "Dublin Core Description"
     And I enter "And when they battle in a puddle, its a tweetle beetle puddle battle" for "edit-metatags-und-description-value"
     And I enter "Fox in socks" for "Page title"
+    And I follow "Dublin Core Title"
     And I enter "Fox in socks" for "edit-metatags-und-dctermstitle-item-value"
     And press "Save"
     Then I should see "Standard page test has been created"
-    And the response should contain "<meta name=\"description\" content=\"And when they battle in a puddle, its a tweetle beetle puddle battle\" />"
+    And the response should contain "<meta name=\"description\" content=\"And when they battle in a puddle, its a tweetle beetle puddle battle\">"
     And the response should contain "<title>Fox in socks</title>"
-    And the response should contain "<meta name=\"dcterms.title\" content=\"Fox in socks\" />"
+    And the response should contain "<meta name=\"dcterms.title\" content=\"Fox in socks\">"

--- a/build/tests/behat/features/reset-password.feature
+++ b/build/tests/behat/features/reset-password.feature
@@ -2,7 +2,7 @@ Feature: Reset Password
 
   Ensure the reset password functionality works
 
-  @api
+  @api @javascript
   Scenario: Reset my password
     Given I am logged in as a user named "peskypaul" with the "Content editor" role that doesn't force password change
     Then I logout

--- a/build/tests/behat/features/role_delegation.feature
+++ b/build/tests/behat/features/role_delegation.feature
@@ -1,7 +1,7 @@
 Feature: Role delegation
   So user management can be delegated to site editors   As a site editor I can alter user roles   except for users that have the administrator role
 
-  @api @role_delegation
+  @api @role_delegation @javascript
   Scenario: Account alteration protection
     Given a user named "joe" with role "administrator" exists
     Given a user named "bob" with role "Content editor" exists

--- a/build/tests/behat/features/search.feature
+++ b/build/tests/behat/features/search.feature
@@ -3,8 +3,7 @@ Feature: Search
   So that all users can search
   As an anonymous user I can use search
 
-  @api
+  @api @javascript
   Scenario: Search API block is present
     Given I am on the homepage
-    Then the response status code should be 200
-    And I should see an "div#block-search-api-page-default-search" element
+    Then I should see an "div#block-search-api-page-default-search" element

--- a/build/tests/behat/features/standard-page.feature
+++ b/build/tests/behat/features/standard-page.feature
@@ -2,13 +2,14 @@ Feature: Standard Page
 
   Ensure the standard page content displayed correctly
 
-  @api
+  @api @javascript
   Scenario: View the about us page
     Given I am logged in as a user named "dean" with the "Content editor" role that doesn't force password change
     When I go to "/node/add/page"
-    Then the response status code should be 200
+    Then I should see "Create Standard page"
     And I enter "About Us" for "Title"
-    And I enter "govCMS is the best!" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "govCMS is the best!" in WYSIWYG editor "body-wysiwyg"
     And press "Save"
     Then I should see "Standard Page About Us has been created"
     Then I logout
@@ -24,5 +25,5 @@ Feature: Standard Page
     And press "Apply"
     Then I logout
     Given I am on "about-us"
-    Then the response status code should be 200
+    Then I should see "About Us"
     And I should see an "nav.breadcrumb:contains(About Us)" element

--- a/build/tests/behat/features/text-formats.feature
+++ b/build/tests/behat/features/text-formats.feature
@@ -4,7 +4,7 @@ Feature: Text formats
   Provide a number of text format options
   # @TODO this is fixed with https://www.drupal.org/node/2304037
 
-  @api
+  @api @javascript
   Scenario: Users can access plain text
     Given I am logged in as a user named "richard" with the "Content editor" role that doesn't force password change
     And I go to "node/add/page"
@@ -12,19 +12,21 @@ Feature: Text formats
     And I should not see "Filtered html"
     And I should not see "Full HTML"
     And I enter "Test node" for "Title"
-    And I enter "<p><h1>Testing</h1><p>" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "<p><h2>Testing</h2><p>" in WYSIWYG editor "body-wysiwyg"
     And I select "Plain text" from "Text format"
     And I press "Save"
     Then I should see "Testing"
     And I should not see the heading "Testing"
 
-  @api
+  @api @javascript
   Scenario: Users can access Rich text
     Given I am logged in as a user named "sally" with the "Content editor" role that doesn't force password change
     And I go to "node/add/page"
     Then I should see "Rich text"
     And I enter "Test node" for "Title"
-    And I enter "<p><h2>Testing</h2></p>" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "<p><h2>Testing</h2><p>" in WYSIWYG editor "body-wysiwyg"
     And I select "Rich text" from "Text format"
     And I press "Save"
     Then I should see the heading "Testing"

--- a/build/tests/behat/features/toc.feature
+++ b/build/tests/behat/features/toc.feature
@@ -2,12 +2,13 @@ Feature: Table of contents
 
   Users can add a table of contents
 
-  @api
+  @api @javascript
   Scenario: Insert table of contents token and render
     Given I am logged in as a user named "john" with the "Content editor" role that doesn't force password change
     And I go to "node/add/page"
     And I enter "Test" for "Title"
-    And I enter "[TOC:ol Table of contents]<h2>Item 1</h2><h2>Item 2</h2><h2>Item 3</h2>" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "[TOC:ol Table of contents]<h2>Item 1</h2><h2>Item 2</h2><h2>Item 3</h2>" in WYSIWYG editor "body-wysiwyg"
     And I press "Save"
     Then I should see an "div.toc-filter" element
     And I should see "Table of contents"

--- a/build/tests/behat/features/wysiwyg.feature
+++ b/build/tests/behat/features/wysiwyg.feature
@@ -6,6 +6,9 @@ Feature: Use ckeditor4 WYSIWYG editor
   Scenario: WYSIWYG editor is operational
     Given I am logged in as a user named "steve" with the "Content editor" role that doesn't force password change
     And I go to "node/add/page"
+    Then I should see "Create Standard page"
+    And I enter "test" for "Title"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
     Then I should see a "div.cke" element
     And I should see an "a.cke_button__bold" element
     And I should see an "a.cke_button__italic" element

--- a/build/tests/behat/features/youtube-embed.feature
+++ b/build/tests/behat/features/youtube-embed.feature
@@ -2,11 +2,12 @@ Feature: Embed YouTube videos in content
 
   Users can embed a YouTube video
 
-  @api
+  @api @javascript
   Scenario: Embed YouTube video
     Given I am logged in as a user named "sam" with the "Content editor" role that doesn't force password change
     And I go to "node/add/page"
     And I enter "Test" for "Title"
-    And I enter "[video:https://www.youtube.com/watch?v=_zzjd1xadyA]" for "Body"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "[video:https://www.youtube.com/watch?v=_zzjd1xadyA]" in WYSIWYG editor "body-wysiwyg"
     And I press "Save"
     Then I should see an "iframe.video-filter" element


### PR DESCRIPTION
Using @javascript means tests will run via headless phantomjs, so we can capture screenshots of failures as artifacts and auto-upload to S3.

The S3 bucket will be publicly accessible and if a failure occurs a link to the fail screenshot capture will display in Travis Logs (demo PR incoming shortly).
