### PR TITLE
Remove conditional classes

### DIFF
--- a/themes/govcms/govcms_zen/templates/html.tpl.php
+++ b/themes/govcms/govcms_zen/templates/html.tpl.php
@@ -7,11 +7,9 @@
  * @see https://drupal.org/node/1728208
  */
 ?><!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7" <?php print $html_attributes; ?>><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7" <?php print $html_attributes; ?>><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8" <?php print $html_attributes; ?>><![endif]-->
-<!--[if IE 8]><html class="lt-ie9" <?php print $html_attributes; ?>><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html <?php print $html_attributes . $rdf_namespaces; ?>><!--<![endif]-->
+
+<!--[if (lt IE 9) ]><html class="lt-ie9" <?php print $html_attributes; ?>> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html <?php print $html_attributes; ?>> <!--<![endif]-->
 
 <head>
   <?php print $head; ?>


### PR DESCRIPTION
I think you should strongly consider removing conditional classes all together with feature detection being a strong preference over browser targeting. See reasons here: http://www.impressivewebs.com/conditional-comments-classes-ie/

The only class name required by the stylesheets appears to be "lt-ie9". You could add a few others if you intended these to be hooks for further development so feel free to modify this PR but there is no situation where IE7Mobile or ie6 should need to be accounted for.
