### PR TITLE
Clean up display of installation forms.

### DIFF
--- a/themes/govcms/govcms_zen/css/govcms_styles.css
+++ b/themes/govcms/govcms_zen/css/govcms_styles.css
@@ -2369,9 +2369,17 @@ footer .block {
 }
 
 .installer .centered-box {
-  text-align: left;
+  text-align: center;
   padding-left: 20px;
+  max-width: 70%;
 }
+.installer .centered-box input, .installer .centered-box fieldset {
+  max-width: 100%;
+}
+.installer .centered-box .form-type-password-confirm .form-item,
+.installer .centered-box .form-type-password-confirm .password-suggestions {
+  margin: 0.7em auto;
+ }
 
 .region-navigation {
   background: #7a797a;

--- a/themes/govcms/govcms_zen/sass/sections/_installer.scss
+++ b/themes/govcms/govcms_zen/sass/sections/_installer.scss
@@ -1,6 +1,14 @@
 .installer {
   .centered-box {
-    text-align: left;
+    text-align: center;
     padding-left: 20px;
+    max-width: 70%;
+    input, fieldset {
+      max-width: 100%;
+    }
+    .form-type-password-confirm .form-item,
+    .form-type-password-confirm .password-suggestions {
+      margin: 0.7em auto;
+    }
   }
 }


### PR DESCRIPTION
A minimal effort attempt as resolving #45.

Makes container wider and centers content within.

![install-1](https://cloud.githubusercontent.com/assets/1256274/10387710/fbebd730-6ea6-11e5-80fb-ed12c1a24f53.png)
![install-2](https://cloud.githubusercontent.com/assets/1256274/10387712/fbf1875c-6ea6-11e5-82a4-21571f35a4fd.png)
![install-3](https://cloud.githubusercontent.com/assets/1256274/10387711/fbf09e28-6ea6-11e5-8ca3-51e568a6b0aa.png)
![install-4](https://cloud.githubusercontent.com/assets/1256274/10387713/fbf30e2e-6ea6-11e5-9ed6-551168697d0e.png)
