### PR TITLE
Increase resolution of PhantomJS failure screenshots.

### DIFF
--- a/build/tests/behat/bootstrap/FeatureContext.php
+++ b/build/tests/behat/bootstrap/FeatureContext.php
@@ -206,6 +206,7 @@ JS;
       if (!($driver instanceof Selenium2Driver)) {
         return;
       }
+      $this->getSession()->resizeWindow(1440, 900, 'current');
       file_put_contents('./screenshot-fail.png', $this->getSession()->getDriver()->getScreenshot());
     }
   }


### PR DESCRIPTION
Bump PhantomJS screenshots to a more reasonable resolution (1440x900).

For #61.
