### PR TITLE
Update Drupal core to 7.40.

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = 7.39
+projects[drupal][version] = 7.40
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
## From the release notes:

Maintenance release of the Drupal 7 series. Includes bug fixes and small API/feature improvements only (no major new functionality); major, non-backwards-compatible new features are only being added to the forthcoming Drupal 8.0 release.

No security fixes are included in this release.

No changes have been made to the web.config or robots.txt files in this release, so upgrading custom versions of those files is not necessary.

There is one change to the .htaccess file in this release:

A change to set the X-Content-Type-Options header to "nosniff" when possible, to prevent certain web browsers from picking an unsafe MIME type (see #462950).
Upgrading custom versions of the .htaccess file to incorporate this change is strongly recommended.

There are two changes to the default settings.php file in this release:

A change to exclude private files from the "404_fast_paths" behavior. This is useful primarily for sites which call drupal_fast_404() directly from settings.php (see #2455057).
A documentation change to make it easier for development sites to enable the 'theme_debug' feature via settings.php (see #2538640).
Upgrading the settings.php files on existing sites is recommended but not required.
