### PR TITLE
Specify govCMS project type as profile in makefile

### DIFF
--- a/build-govcms.make
+++ b/build-govcms.make
@@ -5,4 +5,5 @@ api = 2
 includes[] = drupal-org-core.make
 
 ; Download the govCMS install profile and recursively build all its dependencies:
+projects[govcms][type] = profile
 projects[govcms][version] = 2.x-dev


### PR DESCRIPTION
With Drush 7.10 if we don't specify a project type in makefile, it will be automatically set to module, even if it's actually theme or profile drush-ops/drush#1627 

Many popular distributions have this line in makefile such as
- [ Drupal Commons](http://cgit.drupalcode.org/commons/tree/build-commons.make)
- [open Atrium](http://cgit.drupalcode.org/openatrium/tree/build-openatrium.make)
- [open Publish](http://cgit.drupalcode.org/openpublish/tree/build-openpublish.make)
- [Panopoly](http://cgit.drupalcode.org/panopoly/tree/build-panopoly.make)

This commit can also avoid issues while bumping Drush dependency from current 7.0.0-rc2 to stable release :100: 

thanks
