### PR TITLE
Resolve md5 checksum issue.

### DIFF
--- a/build-govcms.make
+++ b/build-govcms.make
@@ -6,3 +6,4 @@ includes[] = drupal-org-core.make
 
 ; Download the govCMS install profile and recursively build all its dependencies:
 projects[govcms][version] = 2.x-dev
+projects[govcms][download][revision] = "c43f52e7b5792a54eb0bb16e10aaf29293fb7698"


### PR DESCRIPTION
Fixes the current build issue `File govcms-7.x-2.x-dev.tar.gz_date=1445888940 is corrupt (wrong md5 checksum).` by specifying a commit revision for the govCMS project.

Thanks @jozhao!
