### PR TITLE
md5 checksum issue

### DIFF
--- a/build-govcms.make
+++ b/build-govcms.make
@@ -5,4 +5,7 @@ api = 2
 includes[] = drupal-org-core.make
 
 ; Download the govCMS install profile and recursively build all its dependencies:
+projects[govcms][type] = profile
 projects[govcms][version] = 2.x-dev
+projects[govcms][download][type] = git
+projects[govcms][download][branch] = 7.x-2.x


### PR DESCRIPTION
Since Drupal dev branch sometimes returns different md5 hash, this can bring testing troubles. (guessing different caching period between xml file and project) this issue has many reports in community with dev branch.

this can be another option with PR https://github.com/govCMS/govCMS/pull/85

projects[govcms][download][type] = git
projects[govcms][download][branch] = 7.x-2.x
