### PR TITLE
Exclude unpublished nodes from search index

### DIFF
--- a/build/tests/behat/features/search.feature
+++ b/build/tests/behat/features/search.feature
@@ -2,8 +2,63 @@ Feature: Search
 
   So that all users can search
   As an anonymous user I can use search
+  Exclude Unpublished content from search index
 
   @api @javascript
   Scenario: Search API block is present
     Given I am on the homepage
     Then I should see an "div#block-search-api-page-default-search" element
+
+  @api @javascript
+  Scenario: Searching for a content that is published return result
+    Given I am logged in as a user named "mary" with the "Content editor" role that doesn't force password change
+    When I go to "/node/add/news-article"
+    Then I should see "Create News Article"
+    And I enter "govCMS is the best" for "Title"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "the whole of government content management and website hosting service for Australian Government agencies" in WYSIWYG editor "body-wysiwyg"
+    When I press "Save"
+    Then I should see "News Article govCMS is the best has been created"
+    Then I logout
+    Given I am on "search/govCMS"
+    Then I should see the heading "Search"
+    And I should see "Your search yielded no results"
+    Given I am logged in as a user named "jason" with the "Content approver" role that doesn't force password change
+    Given I am on "news-media/news/govcms-best"
+    Then I select "Needs Review" from "state"
+    When I press "Apply"
+    Then I should see "Revision state: Needs Review"
+    Then I logout
+    Given I am logged in as a user named "grace" with the "Content approver" role that doesn't force password change
+    Given I am on "news-media/news/govcms-best"
+    Then I select "published" from "state"
+    When I press "Apply"
+    Then I logout
+    Given I am on "search/govCMS"
+    Then I should see the heading "Search"
+    And I should see "The search found 1 result"
+    And I should see "govCMS is the best"
+
+  @api @javascript
+  Scenario: Searching for a content that is NOT published return no results
+    Given I am logged in as a user named "joseph" with the "Content editor" role that doesn't force password change
+    When I go to "/node/add/news-article"
+    Then I should see "Create News Article"
+    Then I enter "govCMS is the best" for "Title"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    Then I fill in "the whole of government content management and website hosting service for Australian Government agencies" in WYSIWYG editor "body-wysiwyg"
+    When I press "Save"
+    Then I should see "News Article govCMS is the best has been created"
+    Then I logout
+    Given I am on "search/govCMS"
+    Then I should see the heading "Search"
+    And I should see "Your search yielded no results"
+    Given I am logged in as a user named "claire" with the "Content approver" role that doesn't force password change
+    Given I am on "news-media/news/govcms-best"
+    Then I select "Needs Review" from "state"
+    When I press "Apply"
+    Then I should see "Revision state: Needs Review"
+    Then I logout
+    Given I am on "search/govCMS"
+    Then I should see the heading "Search"
+    And I should see "Your search yielded no results"

--- a/build/tests/govcms.test
+++ b/build/tests/govcms.test
@@ -237,6 +237,20 @@ class GovCMSTest extends GovCMSTestBase {
       'workbench_moderation_state_new' => 'published',
     ), t('Save'));
 
+    // Create a draft page.
+    $this->drupalGet('node/add/page');
+    $this->drupalPost(NULL, array(
+      'title' => 'Gold Halo - Draft',
+      'workbench_moderation_state_new' => 'draft',
+    ), t('Save'));
+
+    // Create a needs review page.
+    $this->drupalGet('node/add/page');
+    $this->drupalPost(NULL, array(
+      'title' => 'Gold Halo - needs_review',
+      'workbench_moderation_state_new' => 'needs_review',
+    ), t('Save'));
+
     // Index content.
     $this->cronRun();
     $this->cronRun();
@@ -246,6 +260,8 @@ class GovCMSTest extends GovCMSTestBase {
     $this->assertText('Gods Are Bored');
     $this->drupalGet('search/node/gold');
     $this->assertText('Gold Halo');
+    $this->assertNoText('Gold Halo - Draft');
+    $this->assertNoText('Gold Halo - needs_review');
 
     // Search as anonymous.
     $this->drupalLogout();
@@ -253,6 +269,8 @@ class GovCMSTest extends GovCMSTestBase {
     $this->assertNoText('Gods Are Bored');
     $this->drupalGet('search/node/gold');
     $this->assertText('Gold Halo');
+    $this->assertNoText('Gold Halo - Draft');
+    $this->assertNoText('Gold Halo - needs_review');
 
     // Search as logged in user.
     $user = $this->drupalCreateUser();
@@ -261,6 +279,8 @@ class GovCMSTest extends GovCMSTestBase {
     $this->assertNoText('Gods Are Bored');
     $this->drupalGet('search/node/gold');
     $this->assertText('Gold Halo');
+    $this->assertNoText('Gold Halo - Draft');
+    $this->assertNoText('Gold Halo - needs_review');
   }
 
   /**

--- a/modules/custom/govcms_search_core/govcms_search_core.module
+++ b/modules/custom/govcms_search_core/govcms_search_core.module
@@ -46,7 +46,7 @@ function govcms_search_core_default_search_api_index() {
           }
         },
         "search_api_alter_node_access" : { "status" : 1, "weight" : "0", "settings" : [] },
-        "search_api_alter_node_status" : { "status" : 0, "weight" : "0", "settings" : [] },
+        "search_api_alter_node_status" : { "status" : 1, "weight" : "0", "settings" : [] },
         "search_api_alter_add_hierarchy" : { "status" : 0, "weight" : "0", "settings" : { "fields" : [] } },
         "search_api_alter_add_viewed_entity" : { "status" : 0, "weight" : "0", "settings" : { "mode" : "full" } },
         "search_api_alter_add_url" : { "status" : 0, "weight" : "0", "settings" : [] },


### PR DESCRIPTION
This commit enables the "Exclude unpublished nodes" in search API filters so that we can protect unpublished draft content.

A behat search testing is added including two scenarios
1. Searching for a content that is published return result
2. Searching for a content that is NOT published return no results

@aleayr @invisigoth @ruwanl Once travis is happy, we are ready to merge it in next release.
