### PR TITLE
As a platform administrator I do not want agencies to be able to configure search api so that the search will not break

### DIFF
--- a/modules/custom/govcms_permissions/govcms_permissions.perms.inc
+++ b/modules/custom/govcms_permissions/govcms_permissions.perms.inc
@@ -790,8 +790,6 @@ function govcms_permissions_base_permissions() {
       'administer search_api' => array(
         'roles' => array(
           0 => 'administrator',
-          1 => 'Site editor',
-          2 => 'Site builder',
         ),
       ),
     ),


### PR DESCRIPTION
this issue was originally raised by Sean and he suggested "Remove permissions from all users except administrators." Reference: (GOVCMSDEV-103). 

@aleayr @invisigoth @ruwanl Once travis is happy, we are ready to merge it in next release.
