### PR TITLE
Adding govcms favicon as default favicon to sit in the docroot

### DIFF
--- a/build/phing/build.xml
+++ b/build/phing/build.xml
@@ -217,6 +217,13 @@
         </if>
     </target>
 
+    <target name="mk-favicon"
+            description="Place the govCMS favicon in the docroot directory.">
+        <exec command="cp ${repo.root}/themes/govcms/GOVCMS_STARTERKIT/favicon.ico ${docroot}/"
+              logoutput="true"
+              passthru="true"/>
+    </target>
+
     <target name="phantomjs:launch"
           description="Launches a GhostDriver.">
       <exec command="${phantomjs.bin} --webdriver=${phantomjs.webdriver}"
@@ -252,7 +259,7 @@
             <import file="${repo.root}/build/acsf/phing/acsf_pre_make.build.xml" optional="true" />
           </then>
         </if>
-    
+
         <drush command="make" assume="yes" verbose="TRUE">
             <option name="concurrency">8</option>
             <param>"${drupal.makefile}"</param>
@@ -261,6 +268,9 @@
 
         <!-- Remove robots.txt file -->
         <phingcall target="rm-robotstxt" />
+
+        <!-- Place favicon.ico in the docroot -->
+        <phingcall target="mk-favicon" />
 
         <!-- Run Acquia specific post-make build tasks -->
         <if>
@@ -312,6 +322,9 @@
 
         <!-- Remove robots.txt file -->
         <phingcall target="rm-robotstxt" />
+
+        <!-- Place favicon.ico in the docroot -->
+        <phingcall target="mk-favicon" />
 
         <!-- Run Acquia specific post-make build tasks -->
         <if>


### PR DESCRIPTION
Browsers will always request /favicon.ico as a default location for favicons to load. Especially when HTML is not present to indicate otherwise (metatags). 

When we compile govCMS, we should place the govCMS favicon in place as a "catch all" and to prevent 404 requests of favicons can fall through to Drupal.

/favicons.ico is currently the most frequent 404 on the platform.
