### PR TITLE
Update ACSF connector module to 1.18

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -6,7 +6,7 @@ defaults[projects][subdir] = "contrib"
 ; Contrib modules
 
 projects[accessible_forms][version] = "1.0-alpha1"
-projects[acsf][version] = "1.14"
+projects[acsf][version] = "1.18"
 projects[acquia_connector][version] = "2.15"
 projects[addressfield][version] = "1.1"
 projects[admin_views][version] = "1.5"


### PR DESCRIPTION
The latest release of Acquia Cloud Site Factory 2.34 recommends updating the ACSF module to 1.18. For more information, see https://docs.acquia.com/site-factory/release-notes#release-22611
