### PR TITLE
Allow git to see compiled Drupal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,6 @@ Thumbs.db
 #######################
 .idea
 
-# Ignore Drupal stuff #
-########################
-docroot
-drushrc.php
-
 # Continuous Integration #
 #########################
 bin


### PR DESCRIPTION
This is so that downstream projects don't get conflicts with govCMS's .gitignore ignoring their docroot directory.  This is an unnecessary blocker to upstream contribution.
