### PR TITLE
Do not run install on phing build

### DIFF
--- a/build/phing/build.xml
+++ b/build/phing/build.xml
@@ -141,6 +141,10 @@
     <!-- ============= -->
 
     <target name="build"
+            description="Build the govCMS project."
+            depends="git-reset, make"/>
+
+    <target name="build:install"
             description="Build the project and install govCMS."
             depends="git-reset, make, install"/>
 


### PR DESCRIPTION
`build` is the default command for phing and is documented in our README.md file as the way to build govCMS. However, it will fail for most people. This is because the build command includes an install step which requires an active database connection be available. This also requires additional configuration which is not so well documented.

This patch suggests that build simply run the make step from a clean git checkout and introduces a new build command, `build:install` which can do what build currently does.
