### PR TITLE
Upgrade ACSF module to 1.19

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -6,7 +6,7 @@ defaults[projects][subdir] = "contrib"
 ; Contrib modules
 
 projects[accessible_forms][version] = "1.0-alpha1"
-projects[acsf][version] = "1.18"
+projects[acsf][version] = "1.19"
 projects[acquia_connector][version] = "2.15"
 projects[addressfield][version] = "1.1"
 projects[admin_views][version] = "1.5"


### PR DESCRIPTION
There is a new acsf version (7.x-1.19) on drupal.org that will ensure
that the necessary acsf scripts in the repository are executable before
allowing it to be deployed.
