### PR TITLE
Update Drupal core to 7.42

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.41"
+projects[drupal][version] = "7.42"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
Release notes: https://www.drupal.org/drupal-7.42-release-notes

Maintenance release of the Drupal 7 series. Includes bug fixes and small API/feature improvements only (no major, non-backwards-compatible new functionality).
- No security fixes are included in this release.
- No changes have been made to the robots.txt or default settings.php files in this release, so upgrading custom versions of those files is not necessary.

**There is one change to the .htaccess and web.config files in this release:**

A change to block Composer-related files (in particular, composer.json and composer.lock) from being viewed by website visitors (see https://www.drupal.org/node/2392153).
