### PR TITLE
Update CKEditor to 4.5.7

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -179,7 +179,7 @@ libraries[html5placeholder][directory_name] = "html5placeholder"
 libraries[html5placeholder][type] = "library"
 
 libraries[ckeditor][download][type] = "get"
-libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.4.7/ckeditor_4.4.7_full.zip"
+libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.5.7/ckeditor_4.5.7_full.zip"
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[ckeditor][type] = "library"
 


### PR DESCRIPTION
The current packaged version of CKEditor (4.4.7) is over a year old now and has had 9 releases since then. Version 4.4.8 includes a security update and there are plenty of enhancements and bugfixes in the 4.5.x branch, which is now used in Drupal 8 core.

One particular bug is fixed in 4.5.6 regarding files embedded from the media_wysiwyg plugin. It's probably an edge case and not worth describing, unless I need to further justify upgrading CKEditor.
