### PR TITLE
Wrap Behat tests in travis_wait to prolong timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
 
 script:
   # Run tests
-  - phing -f build/phing/build.xml run-tests
+  - travis_wait phing -f build/phing/build.xml run-tests
 
 after_success:
   - phing -f build/phing/build.xml post-commit


### PR DESCRIPTION
Resolves #178

This has been a common cause for failure in Travis tests recently, as Behat tests do not produce output for longer than 10m and cause a false failure. Using the internal `travis_wait` command should bump this timeout from 10m to 20m.
