### PR TITLE
Disable required HTTPS for composer downloads

### DIFF
--- a/build/composer.json
+++ b/build/composer.json
@@ -29,7 +29,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "secure-http": false
     },
     "scripts": {
       "post-install-cmd": [


### PR DESCRIPTION
Composer is breaking builds complaining about drupal/coder git repo not being downloaded over HTTPS. Thats out of our control, so to continue builds, we need to revert to composer's pervious behaviour to allow it. We can revert this change once the new practice has been accepted by all of our dependancies.
