### PR TITLE
Added GovCMS account security module

### DIFF
--- a/modules/custom/govcms_account_security/govcms_account_security.admin.inc
+++ b/modules/custom/govcms_account_security/govcms_account_security.admin.inc
@@ -53,9 +53,9 @@ function govcms_account_security_admin_settings() {
     '#type' => 'select',
     '#title' => t('HTTP code return to anonymous visits on user profile pages:'),
     '#options' => array(
-      '0' => t(variable_get('user_profile_page_code_anonymous_visit')),
+      '0' => t(variable_get('govcms_account_security_user_profile_page_code_anonymous_visit')),
     ),
-    '#default_value' => variable_get('user_profile_page_code_anonymous_visit'),
+    '#default_value' => variable_get('govcms_account_security_user_profile_page_code_anonymous_visit'),
     '#disabled' => TRUE,
   );
 

--- a/modules/custom/govcms_account_security/govcms_account_security.admin.inc
+++ b/modules/custom/govcms_account_security/govcms_account_security.admin.inc
@@ -2,9 +2,8 @@
 
 /**
  * @file
- * Contains admin paths for govCMS Account
+ * Contains admin paths for govCMS Account Security
  *
- * The original foundation for the govCMS distribution is aGov; the Drupal distribution created by PreviousNext to provide a core set of elements, functionality and features that can be used to develop government websites
  *
  * @copyright Copyright(c) 2015 Commonwealth of Australia as represented by Department of Finance
  * @license GPL v2 http://www.fsf.org/licensing/licenses/gpl.html
@@ -12,7 +11,7 @@
  */
 
 /**
- * Settings form for govcms password policy.
+ * Settings form for govcms account security.
  */
 function govcms_account_security_admin_settings() {
 

--- a/modules/custom/govcms_account_security/govcms_account_security.admin.inc
+++ b/modules/custom/govcms_account_security/govcms_account_security.admin.inc
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ * Contains admin paths for govCMS Account
+ *
+ * The original foundation for the govCMS distribution is aGov; the Drupal distribution created by PreviousNext to provide a core set of elements, functionality and features that can be used to develop government websites
+ *
+ * @copyright Copyright(c) 2015 Commonwealth of Australia as represented by Department of Finance
+ * @license GPL v2 http://www.fsf.org/licensing/licenses/gpl.html
+ * @author Department of Finance
+ */
+
+/**
+ * Settings form for govcms password policy.
+ */
+function govcms_account_security_admin_settings() {
+
+  $form = array();
+
+  drupal_set_message(t("Settings are for review only and cannot be changed."), 'warning');
+
+  $form['govcms_account_security_user_failed_login_user_limit'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Number of failed login attemps allowed before blocking an account:'),
+    '#options' => array(
+      '0' => t(variable_get('user_failed_login_user_limit')),
+    ),
+    '#default_value' => variable_get('user_failed_login_user_limit'),
+    '#disabled' => TRUE,
+  );
+
+  $form['govcms_account_security_user_failed_login_user_window'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Block an account for after failed login limit is reached:'),
+    '#options' => array(
+      '0' => t(variable_get('user_failed_login_user_window').' seconds'),
+    ),
+    '#default_value' => variable_get('user_failed_login_user_window').' seconds',
+    '#disabled' => TRUE,
+  );
+
+  $form['govcms_account_security_user_failed_login_identifier_uid_only'] = array(
+    '#type' => 'select',
+    '#title' => t('Flood control event identifer:'),
+    '#options' => array(
+      '0' => t(variable_get('user_failed_login_identifier_uid_only')?'User ID only':'Both user ID and IP address'),
+    ),
+    '#default_value' => variable_get('user_failed_login_identifier_uid_only')?'User ID only':'Both user ID and IP address',
+    '#disabled' => TRUE,
+  );
+
+  $form['govcms_account_security_user_profile_page_code_anonymous_visit'] = array(
+    '#type' => 'select',
+    '#title' => t('HTTP code return to anonymous visits on user profile pages:'),
+    '#options' => array(
+      '0' => t(variable_get('user_profile_page_code_anonymous_visit')),
+    ),
+    '#default_value' => variable_get('user_profile_page_code_anonymous_visit'),
+    '#disabled' => TRUE,
+  );
+
+  return $form;
+}

--- a/modules/custom/govcms_account_security/govcms_account_security.info
+++ b/modules/custom/govcms_account_security/govcms_account_security.info
@@ -1,0 +1,8 @@
+name = govCMS Account Security
+description = Locking an account after a specified number of failed logon attempts. Prevent user name enumeration on user profile pages.
+project = govcms_account_security
+dependencies[] = password_policy
+package = govCMS
+core = 7.x
+
+

--- a/modules/custom/govcms_account_security/govcms_account_security.install
+++ b/modules/custom/govcms_account_security/govcms_account_security.install
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ * Install file for account lockout.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function govcms_account_security_install() {
+  // ISM 2015, control: 1403, accounts are locked after a maximum of 5 failed logon attempts
+  variable_set('user_failed_login_user_limit', 5);
+  // Lock the offending account for 315400000 seconds (10 years)
+  variable_set('user_failed_login_user_window', 315400000);
+  // Register flood events based on the uid only, see user.module
+  variable_set('user_failed_login_identifier_uid_only', TRUE);
+  // Set HTTP status code returned to anonymous visits on user profile pages
+  variable_set('user_profile_page_code_anonymous_visit', '403');
+  // An accounts with expired password will be forced to change their password upon the next login
+  variable_set('password_policy_block', 1);
+
+}
+
+/**
+ * Implements hook_enable().
+ */
+function govcms_account_security_enable() {
+  $modules_to_disable = array();
+  if(module_exists('login_security')) {
+    $modules_to_disable[] = 'login_security';
+  }
+  if(module_exists('flood_control')) {
+    $modules_to_disable[] = 'flood_control';
+  }
+  if (!empty($modules_to_disable)) {
+    module_disable($modules_to_disable);
+    drupal_set_message(t("Login Security and Flood Control modules are automatically disabled."), 'warning');
+  }
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function govcms_account_security_requirements($phase) {
+  $requirements = array();
+  $t = get_t();
+  if ($phase == 'runtime' && (module_exists('login_security') || module_exists('flood_control'))) {
+    $requirements['govcms_account_security'] = array(
+      'title' => $t('Login Security and Flood Contol'),
+      'value' => $t('Enabled'),
+      'description' => $t('Login Security and Flood Control modules need to be disabled.'),
+      'severity' => REQUIREMENT_INFO,
+    );
+  }
+  return $requirements;
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function govcms_account_security_uninstall() {
+
+  // Delete the variables to use the value set by Drupal's user module
+
+  // Drupal's default value is 5
+  variable_del('user_failed_login_user_limit');
+  // Drupal's default value is 21600
+  variable_del('user_failed_login_user_window');
+  // Delete account security specific var
+  variable_del('user_profile_page_code_anonymous_visit');
+
+}

--- a/modules/custom/govcms_account_security/govcms_account_security.install
+++ b/modules/custom/govcms_account_security/govcms_account_security.install
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Install file for account lockout.
+ * Install file for govcms account security.
  */
 
 /**

--- a/modules/custom/govcms_account_security/govcms_account_security.install
+++ b/modules/custom/govcms_account_security/govcms_account_security.install
@@ -15,7 +15,7 @@ function govcms_account_security_install() {
   // Register flood events based on the uid only, see user.module
   variable_set('user_failed_login_identifier_uid_only', TRUE);
   // Set HTTP status code returned to anonymous visits on user profile pages
-  variable_set('user_profile_page_code_anonymous_visit', '403');
+  variable_set('govcms_account_security_user_profile_page_code_anonymous_visit', '403');
   // An accounts with expired password will be forced to change their password upon the next login
   variable_set('password_policy_block', 1);
 
@@ -67,6 +67,6 @@ function govcms_account_security_uninstall() {
   // Drupal's default value is 21600
   variable_del('user_failed_login_user_window');
   // Delete account security specific var
-  variable_del('user_profile_page_code_anonymous_visit');
+  variable_del('govcms_account_security_user_profile_page_code_anonymous_visit');
 
 }

--- a/modules/custom/govcms_account_security/govcms_account_security.module
+++ b/modules/custom/govcms_account_security/govcms_account_security.module
@@ -8,7 +8,7 @@
 /**
  * Implements hook_menu_alter().
  */
-function govcms_account_security_menu(&$items) {
+function govcms_account_security_menu() {
   // We want to create a review settings link visiable under admin/config/people
   $items['admin/config/people/account_security'] = array(
     'title' => 'Review account security settings',
@@ -19,7 +19,7 @@ function govcms_account_security_menu(&$items) {
     'file' => drupal_get_path('module', 'govcms_account_security') . '/govcms_account_security.admin.inc',
     'description' => 'Review govCMS account security settings.',
   );
-
+  return $items;
 }
 
 /**

--- a/modules/custom/govcms_account_security/govcms_account_security.module
+++ b/modules/custom/govcms_account_security/govcms_account_security.module
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_menu_alter().
+ * Implements hook_menu().
  */
 function govcms_account_security_menu() {
   // We want to create a review settings link visiable under admin/config/people
@@ -16,7 +16,7 @@ function govcms_account_security_menu() {
     'page arguments' => array('govcms_account_security_admin_settings'),
     'access callback' => 'user_access',
     'access arguments' => array('administer users'),
-    'file' => drupal_get_path('module', 'govcms_account_security') . '/govcms_account_security.admin.inc',
+    'file' => 'govcms_account_security.admin.inc',
     'description' => 'Review govCMS account security settings.',
   );
   return $items;

--- a/modules/custom/govcms_account_security/govcms_account_security.module
+++ b/modules/custom/govcms_account_security/govcms_account_security.module
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @file
+ * govCMS Account Security
+ */
+
+/**
+ * Implements hook_menu_alter().
+ */
+function govcms_account_security_menu_alter(&$items) {
+
+  $items['admin/config/people/account_security'] = array(
+    'title' => 'Review account security settings',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('govcms_account_security_admin_settings'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer users'),
+    'file' => drupal_get_path('module', 'govcms_account_security') . '/govcms_account_security.admin.inc',
+    'description' => 'Review govCMS account security settings.',
+  );
+
+}
+
+/**
+ * Implementation of hook_form_FORM_ID_alter()
+ */
+function govcms_account_security_form_user_pass_reset_alter(&$form, &$form_state, $form_id) {
+  if(isset($form_state['build_info']['args'][0]) && $form_state['build_info']['args'][0] > 0) {
+    $uid = $form_state['build_info']['args'][0];
+    // Check if the user attempting to reset their password is flood controlled
+    if (!flood_is_allowed('failed_login_attempt_user', variable_get('user_failed_login_user_limit'), variable_get('user_failed_login_user_window'), $uid)) {
+      $timestamp = $form_state['build_info']['args'][1];
+      $hashed_pass = $form_state['build_info']['args'][2];
+      $users = user_load_multiple(array($uid), array('status' => '1'));
+      $current = REQUEST_TIME;
+      // Validate the password reset link
+      if ($timestamp <= $current && $account = reset($users)) {
+        if ($account->uid && $timestamp >= $account->login && $timestamp <= $current && $hashed_pass == user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid)) {
+          // Clear flood control events for the user
+          flood_clear_event('failed_login_attempt_user', $uid);
+          watchdog('user', 'Flood events have been cleared for %user.', $uid);
+          drupal_set_message(t('Your account has been unblocked.'));
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function govcms_account_security_form_alter(&$form, &$form_state, $form_id) {
+  switch ($form_id) {
+    case 'user_login':
+    case 'user_login_block':
+      $user_login_final_validate_index = array_search('user_login_final_validate', $form['#validate']);
+      if ($user_login_final_validate_index >= 0) {
+        $form['#validate'][$user_login_final_validate_index] = 'govcms_account_security_final_validate';
+      }
+    break;
+  }
+}
+
+/**
+ * The final validation handler on the login form.
+ *
+ * Sets a form error if user has not been authenticated, or if too many
+ * logins have been attempted. This validation function should always
+ * be the last one.
+ */
+function govcms_account_security_final_validate($form, &$form_state) {
+  if (empty($form_state['uid'])) {
+    // Always register an IP-based failed login event.
+    flood_register_event('failed_login_attempt_ip', variable_get('user_failed_login_ip_window', 3600));
+    // Register a per-user failed login event.
+    if (isset($form_state['flood_control_user_identifier'])) {
+      flood_register_event('failed_login_attempt_user', variable_get('user_failed_login_user_window', 21600), $form_state['flood_control_user_identifier']);
+    }
+    if (isset($form_state['flood_control_triggered'])) {
+        form_set_error('name', t('Unrecognised username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
+    }
+    else {
+      form_set_error('name', t('Unrecognised username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
+      watchdog('user', 'Login attempt failed for %user.', array('%user' => $form_state['values']['name']));
+    }
+  }
+  elseif (isset($form_state['flood_control_user_identifier'])) {
+    // Clear past failures for this user so as not to block a user who might
+    // log in and out more than once in an hour.
+    flood_clear_event('failed_login_attempt_user', $form_state['flood_control_user_identifier']);
+  }
+}
+
+/**
+ * Implements hook_init().
+ */
+function govcms_account_security_init() {
+  if (!user_is_logged_in()) {
+    $alias = drupal_get_path_alias(current_path());
+    if (drupal_match_path($alias, 'users/*')) {
+      // Throw an access denied error to any user profile page.
+      // By default we don't want to throw a 404 code because search 404 will then expose the user ID if the path actually exists
+      $code_to_return = variable_get('user_profile_page_code_anonymous_visit', '403');
+      if ($code_to_return == '404') {
+        drupal_not_found();
+      } else {
+        drupal_access_denied();
+      }
+    }
+  }
+}

--- a/modules/custom/govcms_account_security/govcms_account_security.module
+++ b/modules/custom/govcms_account_security/govcms_account_security.module
@@ -8,8 +8,8 @@
 /**
  * Implements hook_menu_alter().
  */
-function govcms_account_security_menu_alter(&$items) {
-
+function govcms_account_security_menu(&$items) {
+  // We want to create a review settings link visiable under admin/config/people
   $items['admin/config/people/account_security'] = array(
     'title' => 'Review account security settings',
     'page callback' => 'drupal_get_form',
@@ -65,9 +65,13 @@ function govcms_account_security_form_alter(&$form, &$form_state, $form_id) {
 /**
  * The final validation handler on the login form.
  *
- * Sets a form error if user has not been authenticated, or if too many
- * logins have been attempted. This validation function should always
- * be the last one.
+ * Provide a more generic error message on failed logins excessive failed
+ * login attempts. According to the govCMS security team: "In relation to
+ * the generic message this is consistent with current security practices
+ * for Government online services to avoid disclosure of the password
+ * management policy which could aid an attacker in developing more
+ * targeted attacks, e.g. denial of service, compromise of credentials,
+ * etc."
  */
 function govcms_account_security_final_validate($form, &$form_state) {
   if (empty($form_state['uid'])) {
@@ -99,9 +103,8 @@ function govcms_account_security_init() {
   if (!user_is_logged_in()) {
     $alias = drupal_get_path_alias(current_path());
     if (drupal_match_path($alias, 'users/*')) {
-      // Throw an access denied error to any user profile page.
-      // By default we don't want to throw a 404 code because search 404 will then expose the user ID if the path actually exists
-      $code_to_return = variable_get('user_profile_page_code_anonymous_visit', '403');
+      // Throw an access denied or not found error to any user profile page.
+      $code_to_return = variable_get('govcms_account_security_user_profile_page_code_anonymous_visit', '403');
       if ($code_to_return == '404') {
         drupal_not_found();
       } else {

--- a/modules/custom/govcms_account_security/govcms_account_security.module
+++ b/modules/custom/govcms_account_security/govcms_account_security.module
@@ -58,7 +58,7 @@ function govcms_account_security_form_alter(&$form, &$form_state, $form_id) {
       if ($user_login_final_validate_index >= 0) {
         $form['#validate'][$user_login_final_validate_index] = 'govcms_account_security_final_validate';
       }
-    break;
+      break;
   }
 }
 
@@ -82,7 +82,7 @@ function govcms_account_security_final_validate($form, &$form_state) {
       flood_register_event('failed_login_attempt_user', variable_get('user_failed_login_user_window', 21600), $form_state['flood_control_user_identifier']);
     }
     if (isset($form_state['flood_control_triggered'])) {
-        form_set_error('name', t('Unrecognised username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
+      form_set_error('name', t('Unrecognised username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
     }
     else {
       form_set_error('name', t('Unrecognised username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
@@ -100,9 +100,21 @@ function govcms_account_security_final_validate($form, &$form_state) {
  * Implements hook_init().
  */
 function govcms_account_security_init() {
-  if (!user_is_logged_in()) {
+  if (!user_is_logged_in() && module_exists('pathauto')) {
     $alias = drupal_get_path_alias(current_path());
-    if (drupal_match_path($alias, 'users/*')) {
+    $user_alias_pattern = variable_get('pathauto_user_pattern');
+    if (isset($user_alias_pattern) && !empty($user_alias_pattern)) {
+      // We only need to protect the login names. As Pathauto does not
+      // automatically update existing user aliases when the pattern is
+      // changed, aliases generated using the old pattern will not be
+      // protected until a bulk update is performed.
+      if (strpos($user_alias_pattern, '[user:name]') === FALSE) {
+        $user_alias_pattern = 'users/*';
+      } else {
+        $user_alias_pattern = str_replace('[user:name]', '*', $user_alias_pattern);
+      }
+    }
+    if (drupal_match_path($alias, $user_alias_pattern)) {
       // Throw an access denied or not found error to any user profile page.
       $code_to_return = variable_get('govcms_account_security_user_profile_page_code_anonymous_visit', '403');
       if ($code_to_return == '404') {


### PR DESCRIPTION
(1) Addressed govCMS127 - As a user attempting to login, when I get my password incorrect a number of times, my status becomes blocked, and Drupal does not then send password reset emails.
(2) Addressed govCMS193 - Flood control status will be removed after a password reset link is followed
(3) Addressed issue - user name enumeration still possible on user profile page

Also a more generic message will be displayed when failed login limit is reached. This is consistent with current security practices for Government online services to avoid disclosure of the password management policy which could aid an attacker in developing more targeted attacks, e.g. denial of service, compromise of credentials, etc. 
