### PR TITLE
Removed ACSF module as tracked dependancy

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -6,7 +6,6 @@ defaults[projects][subdir] = "contrib"
 ; Contrib modules
 
 projects[accessible_forms][version] = "1.0-alpha1"
-projects[acsf][version] = "1.19"
 projects[acquia_connector][version] = "2.15"
 projects[addressfield][version] = "1.1"
 projects[admin_views][version] = "1.5"


### PR DESCRIPTION
As we no longer track SaaS integration dependancies (as they don't value anybody but the SaaS platform), the ACSF module is no longer needed in the distribution.
