### PR TITLE
#271 Drupal 7.43 regression - govCMS 2.x

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -4,3 +4,4 @@ projects[drupal][version] = "7.44"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch
+projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-n2678822-22.patch


### PR DESCRIPTION
Issue #271 

This patch is in Drupal core 7.x line but labeled as 7.50.
