### PR TITLE
Drupal core 7.50 update

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,7 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.44"
+projects[drupal][version] = "7.50"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch
-projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-n2678822-22.patch


### PR DESCRIPTION
For issue #295
- Update Drupal core to 7.50
- Remove patch for https://www.drupal.org/node/2678822
