### PR TITLE
Added the new 'administer fields' permission to relevant roles

### DIFF
--- a/modules/custom/govcms_permissions/govcms_permissions.perms.inc
+++ b/modules/custom/govcms_permissions/govcms_permissions.perms.inc
@@ -1024,5 +1024,13 @@ function govcms_permissions_base_permissions() {
         ),
       ),
     ),
+    'field' => array(
+      'administer fields' => array(
+        'roles' => array(
+          0 => 'administrator',
+          1 => 'Site builder',
+        ),
+      ),
+    ),
   );
 }


### PR DESCRIPTION
For issue #295:
Added the new administer fields role (from the 7.50 update in PR #296) to administrator and Site builder roles.
