### PR TITLE
Enable govCMS account security module by default

### DIFF
--- a/govcms.info
+++ b/govcms.info
@@ -152,6 +152,7 @@ dependencies[] = user_action_report
 
 ; govCMS
 
+dependencies[] = govcms_account_security
 dependencies[] = govcms_appearance
 dependencies[] = govcms_core
 dependencies[] = govcms_common_fields


### PR DESCRIPTION
About half a dozen agencies in the first half of this year have reported account lockout issues with GovCMS, which have been successfully resolved by enabling the “Account Security” module. It is about time to enable this module by default so agencies with accounts disabled by the default security settings in GovCMS can resolve those issues by requesting password reset emails.
