### PR TITLE
Tidy up build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ build/bin/phing -f build/phing/build.xml build
 
 This will construct a copy of the govCMS Drupal codebase in the `docroot` directory using instructions from the govcms.make file.
 
+This build is configured to use (http://govcms.local/) by default and will need to [add an entry to your host file](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/). This and other credentials can be changed by duplicating `build/phing/example.build.properties` as `build.properties` and making changes there.
+
 
 
 ## Structure
@@ -70,7 +72,7 @@ export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "ht
 ### Phing
 
 - **build.xml** - Contains project specific configuration and tasks that can be executed across this projects team.
-- **build.properties** - Environment specific configuration. Just like *behat.local.yml*, typically this will assign the url of the current environment. 
+- **build.properties** - Environment specific configuration. Just like *behat.local.yml*, typically this will assign the url of the current environment.
 
 The variables that Phing uses are configured at the top of build.xml. If there are alterations to these parameters to allow Phing to run locally, these may be placed in the *build.properties* file. This file is ignored from git so local modifications will not be committed. To alter the base URL for the Drupal site the following may be added to *build.properties*.
 

--- a/build/phing/build.xml
+++ b/build/phing/build.xml
@@ -39,7 +39,7 @@
               value="${repo.root}/drupal-org.make"
               override="true"/>
     <property name="drupal.base_url"
-              value="http://localhost/"/>
+              value="http://govcms.local/"/>
 
     <property name="profile.modules.custom.path"
               value="${repo.root}/modules"
@@ -59,7 +59,7 @@
     <!-- Credentials -->
     <property name="db.username" value="root"/>
     <property name="db.password" value=""/>
-    <property name="db.name" value="travis_ci_govcms_drupal"/>
+    <property name="db.name" value="govcms_drupal_7"/>
     <property name="db.host" value="localhost"/>
     <property name="db.port" value="3306"/>
     <property name="account.name" value="admin"/>

--- a/build/tests/behat/behat.govcms.yml
+++ b/build/tests/behat/behat.govcms.yml
@@ -1,0 +1,5 @@
+# Local behat settings.
+default:
+  extensions:
+    Behat\MinkExtension:
+      base_url: http://govcms.local/

--- a/build/tests/behat/behat.yml
+++ b/build/tests/behat/behat.yml
@@ -25,4 +25,5 @@ default:
         root: ../../docroot
 
 imports:
+  - behat.govcms.yml
   - behat.local.yml


### PR DESCRIPTION
drupal.base_url in build.xml:
localhost -> govcms.local

db.name:
travis_ci_govcms_drupal -> govcms_drupal_7

Remove .travis.yml file - left over file that is no longer used.

Created behat.govcms.yml

update README to mention hosts file entry for govcms.local + options
update creds in 'build.properties'
