### PR TITLE
#370 Patch for Twitter Block module - Twitter widgets deprecated

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -153,6 +153,7 @@ projects[token_tweaks][download][url] = "https://git.drupal.org/project/token_tw
 projects[token_tweaks][download][revision] = "75818fbfb97bf8882ca106e6af703be7644b11bb"
 projects[transliteration][version] = "3.2"
 projects[twitter_block][version] = "2.3"
+projects[twitter_block][patch][] = "https://www.drupal.org/files/issues/twitter_block-2751845-5.patch"
 projects[username_enumeration_prevention][version] = "1.0"
 projects[userprotect][version] = "1.1"
 projects[uuid][version] = "1.0-alpha6"


### PR DESCRIPTION
#370

This patch is from https://www.drupal.org/node/2751845
