### PR TITLE
Update to Drupal 7.52

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.51"
+projects[drupal][version] = "7.52"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
Updating govCMS to respond to the latest security update from Drupal.org