### PR TITLE
Added wysiwyg_abbr module

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -179,6 +179,7 @@ projects[wysiwyg][version] = "2.x-dev"
 projects[wysiwyg][download][type] = "git"
 projects[wysiwyg][download][url] = "http://git.drupal.org/project/wysiwyg.git"
 projects[wysiwyg][download][revision] = "4efd47771a7fce77eb0364c747e3c76a6a65c460"
+projects[wysiwyg_abbr][version] = "1.0"
 projects[wysiwyg_filter][version] = "1.6-rc2"
 projects[xmlsitemap][version] = "2.3"
 


### PR DESCRIPTION
This PR adds the WYSIWYG Abbreviation module, to allow the addition of abbreviations easily through the interface.

It can be enabled through WYSIWYG Profiles in Configuration:
/admin/config/content/wysiwyg/profile/rich_text/edit

Select the Abbreviation checkbox and confirm the button is now available in the editor.