### PR TITLE
Update pathologic to 3.1 (from 3.0-beta2)

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -104,7 +104,7 @@ projects[password_policy][version] = "1.11"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.
 projects[pathauto_persist][version] = "1.4"
-projects[pathologic][version] = "3.0-beta2"
+projects[pathologic][version] = "3.1"
 projects[pci_update][version] = "1.0"
 projects[pci_update][patch][] = "https://www.drupal.org/files/issues/pci_update_password_field_0.patch"
 projects[phone][version] = "1.0-beta1"


### PR DESCRIPTION
Fixes #439 

https://www.drupal.org/project/pathologic/releases/7.x-3.1

Release notes
Changes since 7.x-3.0:
Fixes "local settings" functionality not working as documented. Oops.

Release notes
Changes since 7.x-3.0-beta2:
The most important change in Pathologic 7.x-3.x is that there is now a "global" configuration form, making it possible for all instances of the Pathologic filter across all of your site's text formats to share the same configuration without having to keep each instance's settings form manually in synch. However, individual instances can still use their own configuration instead of the global configuration; this will be the default behavior on all instances on your site when you upgrade from Pathologic 7.x-2.x to Pathologic 7.x-3.x. This global configuration pattern is also used in the Drupal 8 version of Pathologic, so please do upgrade to 7.x-3.x if you eventually plan on upgrading your Drupal 7 site to Drupal 8 in the future! Please read the "Upgrading from Pathologic 7.x-2.x" section of Pathologic's documentation page for more information.

Besides this, there have been various bug fixes and tweaks.