### PR TITLE
Update acquia_connector to 7.x-3.1 (from 7.x-2.15)

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -6,7 +6,7 @@ defaults[projects][subdir] = "contrib"
 ; Contrib modules
 
 projects[accessible_forms][version] = "1.0-alpha1"
-projects[acquia_connector][version] = "2.15"
+projects[acquia_connector][version] = "3.1"
 projects[addressfield][version] = "1.1"
 projects[admin_views][version] = "1.6"
 projects[agls][version] = "1.0-beta3"


### PR DESCRIPTION
https://www.drupal.org/project/acquia_connector/releases/7.x-3.1

Fixes #477 

Release notes (7.x-3.1)
Introduction of connection auto-switching in the Acquia Search module.

Release notes (7.x-3.0)
This Acquia Connector module release for Drupal 7 (download ) is the current recommended version for Drupal 7 websites.

Important
Acquia Connector 7.x-3.x is required to use Acquia Insight with the new Acquia Cloud interface.
If your website is not hosted on Acquia Cloud, to ensure that its information continues to be reported to Acquia Insight, after upgrading the module you must specify the website’s name in the module's interface. For details, see the Status page on your Drupal website.

Change
Acquia Insight on the new Acquia Cloud interface (https://cloud.acquia.com) **does not** support Drupal multisite installations.
