### PR TITLE
Update paranoia to 7.x-1.7 (from 7.x-1.4)

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -99,7 +99,7 @@ projects[openaccess][version] = "1.0"
 projects[panels][version] = "3.9"
 projects[paragraphs][version] = "1.0-rc5"
 projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_workbench_moderation-2603424-19.patch"
-projects[paranoia][version] = "1.4"
+projects[paranoia][version] = "1.7"
 projects[password_policy][version] = "1.11"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.


### PR DESCRIPTION
## https://www.drupal.org/project/paranoia/releases/7.x-1.7

Release notes
- #2846860 by badjava: Form validate function should be array item
- #2846876 by badjava: Add devel execute PHP form block as a risky form
- #2466409 by badjava: Unsetting permission checkboxes causes PHP notices with Fast Permissions Administration module
- #2599740 by jribeiro: sql-sanitize to cache_* tables
- #2782147 by banviktor: Delete variables that contain the word token (e.g. twilio_token) in sanitize script

## https://www.drupal.org/project/paranoia/releases/7.x-1.6

Release notes
- #2640480 greggles, coltrane: this and the build caused double-prefixing and tables to be truncated
- #2640480 greggles, dpintats, c4rl: fix review feedback
- #2640480greggles: add a sanitize whitelist system
- #2565759 by gabrielmachadosantos: Make purging inactive users optional
- #2313945 by greggles: block all "import foo" boxes that use php arrays as a data structure
- #2294061 by greggles: Remove all sessions for a uid if password is changed

## https://www.drupal.org/project/paranoia/releases/7.x-1.5

Release notes
- Code style issues
- #2359095 by greggles: Add auto_username
- #2053075 by greggles: prevent PHP execution by Skinr module
- #2476739 by mglaman, greggles: Add hook to deny access to menu paths
- #2462509 by mglaman: Block ctools' custom PHP access
- #1884338 by douggreen, Matt V.: more sanitizing - usernames/emails
- #2430281 by greggles: Disable the ds_format module from display suite to avoid php eval
- #2401063 by drumm: Hide 'use PHP for service [links] visibility' permission
- #2429899 by greggles: Prevent auto_entitylabel.module 'use PHP for label patterns'
- #2031017 by greggles: re-run the risky permissions remover in hook_modules_enabled
- #2261005 by loopduplicate: First time install fails
- #2429543 by klausi: Rules "bypass rules access" should not be blacklisted