### PR TITLE
[GOVCMS-1385] govCMS distribution cleanup - stage 1

### DIFF
--- a/govcms.info
+++ b/govcms.info
@@ -161,7 +161,6 @@ dependencies[] = govcms_chosen
 dependencies[] = govcms_contact
 dependencies[] = govcms_front
 dependencies[] = govcms_menu_block
-dependencies[] = govcms_register
 dependencies[] = govcms_slideshow
 dependencies[] = govcms_superfish_configuration
 dependencies[] = govcms_sitemap

--- a/govcms.install
+++ b/govcms.install
@@ -1675,3 +1675,13 @@ function govcms_update_7201() {
     module_enable(array('token_tweaks'));
   }
 }
+
+/**
+ * Deprecate and disable the modules.
+ */
+function govcms_update_7202() {
+  if (module_exists('govcms_register')) {
+    module_disable(array('govcms_register'));
+    drupal_uninstall_modules(array('govcms_register'), FALSE);
+  }
+}

--- a/govcms.profile
+++ b/govcms.profile
@@ -72,5 +72,6 @@ function govcms_system_info_alter(&$info, $file, $type) {
 function govcms_paranoia_hide_modules() {
   return array(
     'pathauto_persist' => 'Other',
+    'govcms_register' => 'govCMS',
   );
 }


### PR DESCRIPTION
govCMS 7 housekeeping

This is stage 1, we will remove the module itself in next release (govCMS 2.16) after it is disabled and uninstalled in this release(govCMS 2.15)