### PR TITLE
Update password_policy to 7.x-1.14 (from 7.x-1.11)

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -98,11 +98,7 @@ projects[openaccess][version] = "1.0"
 projects[panels][version] = "3.9"
 projects[paragraphs][version] = "1.0-rc5"
 projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_workbench_moderation-2603424-19.patch"
-<<<<<<< HEAD
 projects[paranoia][version] = "1.7"
-=======
-projects[paranoia][version] = "1.4"
->>>>>>> b2d555e6f8eeb49f4e1ff354a6537db31c71c1cd
 projects[password_policy][version] = "1.14"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -100,7 +100,7 @@ projects[panels][version] = "3.9"
 projects[paragraphs][version] = "1.0-rc5"
 projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_workbench_moderation-2603424-19.patch"
 projects[paranoia][version] = "1.4"
-projects[password_policy][version] = "1.11"
+projects[password_policy][version] = "1.14"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.
 projects[pathauto_persist][version] = "1.4"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -99,7 +99,7 @@ projects[panels][version] = "3.9"
 projects[paragraphs][version] = "1.0-rc5"
 projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_workbench_moderation-2603424-19.patch"
 projects[paranoia][version] = "1.7"
-projects[password_policy][version] = "1.11"
+projects[password_policy][version] = "1.14"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.
 projects[pathauto_persist][version] = "1.4"

--- a/modules/custom/govcms_password_policy/govcms_password_policy.module
+++ b/modules/custom/govcms_password_policy/govcms_password_policy.module
@@ -100,9 +100,9 @@ function govcms_password_policy_get_policies() {
     'enabled' => 1,
     'expiration' => 90,
     'warning' => 7,
-    'policy' => array(
+    'constraints' => array(
       "alphanumeric" => "1",
-      "complexity" => "3",
+      "character_types" => "3",
       "delay" => "24",
       "history" => "8",
       "length" => "11",
@@ -119,7 +119,7 @@ function govcms_password_policy_get_policies() {
     'enabled' => 1,
     'expiration' => 90,
     'warning' => 7,
-    'policy' => array(
+    'constraints' => array(
       "alphanumeric" => "1",
       "delay" => "24",
       "history" => "8",
@@ -145,7 +145,7 @@ function govcms_password_policy_get_policies() {
 function govcms_password_policy_create_policy($settings) {
 
   // Policy settings should be serialised.
-  $settings['policy'] = serialize($settings['policy']);
+  $settings['constraints'] = serialize($settings['constraints']);
 
   // Remove the roles key to process separately.
   $roles = $settings['roles'];


### PR DESCRIPTION
## https://www.drupal.org/project/password_policy/releases/7.x-1.14

Release notes
This release fixes a bug that could, under certain circumstances, prevent users from setting or changing passwords.

A site is affected by the bug only if it is using the "Character Types" ("Complexity") constraint and the module was updated from 7.x-1.11 or lower directly to 7.x-1.13, skipping 7.x-1.12. See #2873715: Update 7105 faulty under certain circumstances for details.

There are no other changes in this release.

## https://www.drupal.org/project/password_policy/releases/7.x-1.13

Release notes
- #985758 by AohRveTPV, sumthief, marlonleandropereira, John Cook: Implement Features hooks to export and import configurations
- #2677500 by AohRveTPV, ameymudras: Adding policy with same name as existing policy causes error
- #2867215 by AohRveTPV: Delete button on policy edit page does not work
- #2863756 by AohRveTPV, BR0kEN: Unnecessary t() calls in tests
- #2865115 by l0ke, AohRveTPV: Quote strings in consistent manner
- #2572297 by AohRveTPV, coolestdude1, mstrelan: Allow modules to provide default path exclusions to forced password change
- #2833776 by mithenks, AohRveTPV: Multiple warning mails sent per day in certain condition
- #2715281 by rocket777, Diego_Mow, AohRveTPV, harivenuv, aks22, jrglasgow: password_policy_force_change table has no primary key
- #2857748 by AohRveTPV: Password expiration tests do not reliably pass
- #2688123 by firewaller, natew, sylus, COBadger: Notice: Undefined property: stdClass::$original
- #2785839 by nullkernel: Allow custom password change path
- #2765003 by Shlyapkin Grigoriy: Enforce check plain on password policies overview form
- #2663704 by AohRveTPV, jaydub: PHP out of memory issue with Force Password Change
- Improve to test against incorrect re-expiration.
- #2647176 by AohRveTPV, eelkeblok: Rename 'policy' field to 'constraints'
- #2627908 by AohRveTPV: Password Expiration Warning: not entirely clear
- #2622934 by AohRveTPV, paulbeaney: Updates to user account during cron generate watchdog error
- #2571139 by AohRveTPV: Fatal error when saving user account
- Cleaned up some code.

## https://www.drupal.org/project/password_policy/releases/7.x-1.12

Release notes
- #2469681 by AohRveTPV: Expiration warnings may not be sent if cron not run daily
- #2566535 by AohRveTPV: Duplicate update functions
- #2468449 by AohRveTPV: Cannot unblock reblocked expired account
- #2464895 by AohRveTPV: Rename "complexity" constraint
- #2562449 by AohRveTPV, mikebarkas: Saving the user node edit form may not unblock user
- #2455881 by AohRveTPV: Improve README.txt
- #2476113 by AohRveTPV: Exempting uid 1 from expiration is insecure default
- #2543798 by AohRveTPV: Make test names and descriptions more consistent
- #2527824 by AohRveTPV: No tests for "Admin (UID=1) password expires." setting
- #2490548 by AohRveTPV: In history constraint validation $account object is modified
- #2464779 by AohRveTPV: 7.x-1.x using D6-style tokens
- #2461665 by AohRveTPV: Add tests for expiration e-mails
- #2467941 by AohRveTPV: Mock time retrievals for testing
- #1332000 by AohRveTPV, erikwebb, rooby, slip, hanoii: Feature to exclude pages from force password change
- #2464835 by AohRveTPV: password_policy.js unused
- #2475553 by AohRveTPV: Add type hinting
- #2462647 by AohRveTPV: Two password history entries created for new users, one invalid
- #2464881 by AohRveTPV: Replace time() with REQUEST_TIME where possible
- #2464503 by sveldkamp: Complexity error message is misleading/confusing
- #2463527 by AohRveTPV: No tests for forced password changes using Password Change Tab
- Made various code improvements that should not affect behavior.