### PR TITLE
Remove google_analytics_reports module from the distribution dependencies

### DIFF
--- a/govcms.info
+++ b/govcms.info
@@ -65,7 +65,6 @@ dependencies[] = file_entity
 dependencies[] = file_lock
 dependencies[] = globalredirect
 dependencies[] = googleanalytics
-dependencies[] = google_analytics_reports
 dependencies[] = honeypot
 dependencies[] = libraries
 dependencies[] = link


### PR DESCRIPTION
Don't think it is a good idea to read the Google analytics reports from the site backend. However, we will keep it in the distribution for legacy reasons.

Limits and Quotas on API Requests https://developers.google.com/analytics/devguides/reporting/core/v3/limits-quotas#core_reporting
