### PR TITLE
Use xmlsitemap 7.x-2.5 stable release (instead of 7.x-2.x-dev)

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -183,10 +183,7 @@ projects[wysiwyg][download][url] = "http://git.drupal.org/project/wysiwyg.git"
 projects[wysiwyg][download][revision] = "4efd47771a7fce77eb0364c747e3c76a6a65c460"
 projects[wysiwyg_abbr][version] = "1.0"
 projects[wysiwyg_filter][version] = "1.6-rc2"
-projects[xmlsitemap][version] = "2.x-dev"
-projects[xmlsitemap][download][type] = "git"
-projects[xmlsitemap][download][url] = "https://git.drupal.org/project/xmlsitemap.git"
-projects[xmlsitemap][download][revision] = "046c34f1e192539c69becab69c5683f79928dc60"
+projects[xmlsitemap][version] = "2.5"
 
 ; Themes
 projects[zen][version] = "5.5"


### PR DESCRIPTION
2.5 tag at same commit as previous version