### PR TITLE
(3.x) SA-CORE-2018-006 - Update Drupal core to 7.60 (from 7.59)

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.59"
+projects[drupal][version] = "7.60"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
## https://www.drupal.org/sa-core-2018-006

## https://www.drupal.org/project/drupal/releases/7.60

Release notes
Maintenance and security release of the Drupal 7 series.

This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

Drupal core - Multiple vulnerabilities - SA-CORE-2018-006
No other fixes are included.

No changes have been made to the .htaccess, web.config, robots.txt or default settings.php files in this release, so upgrading custom versions of those files is not necessary.

Known issues:
When combined with particular configurations of the Domain Access module, this release can cause fatal errors on certain pages of the site. See this issue for more discussion and a possible patch.