### PR TITLE
better amazeeio-network fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Start amazeeio-network
-          command: docker network prune -f && docker network create amazeeio-network || true
+          command: docker network prune -f && docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
       - run:
           name: Build project
           command: |


### PR DESCRIPTION
fixes a condition in #738 that causes the network to not create on hosted CircleCI