### PR TITLE
Create docker images in govcms instead of govcmsdev

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -21,6 +21,3 @@ LOCALDEV_URL=http://govcms.docker.amazee.io
 
 # Namespace for resulting Docker images.
 DOCKERHUB_NAMESPACE=govcms
-
-# @todo: Remove after demo.
-DOCKERHUB_NAMESPACE=govcmsdev


### PR DESCRIPTION
This will permit a CI push to the govcms namespace on dockerhub instead of govcmsdev