### PR TITLE
[SA-Contrib-2018-077]: Updates password policy to 1.16

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -104,7 +104,7 @@ projects[panels][version] = "3.9"
 projects[paragraphs][version] = "1.0-rc5"
 projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_workbench_moderation-2603424-19.patch"
 projects[paranoia][version] = "1.7"
-projects[password_policy][version] = "1.14"
+projects[password_policy][version] = "1.16"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.
 projects[pathauto_persist][version] = "1.4"

--- a/modules/custom/govcms_password_policy/govcms_password_policy.module
+++ b/modules/custom/govcms_password_policy/govcms_password_policy.module
@@ -96,7 +96,7 @@ function govcms_password_policy_get_policies() {
   // Define the password policy.
   $policies['ism_2013_strong'] = array(
     'name' => 'Australian Government ISM Policy (Strong)',
-    'description' => 'Strong password policy that conforms to Australian Government ISM Control: 0421; Revision: 2; Updated: Sep-12;.',
+    'description' => 'Strong password policy that conforms to Australian Government ISM Control: 0421; Revision: 2; Updated: Jan-22-2019.',
     'enabled' => 1,
     'expiration' => 90,
     'warning' => 7,
@@ -116,7 +116,7 @@ function govcms_password_policy_get_policies() {
   // Define the password policy for ISM 2013
   $policies['ism_2013_weak'] = array(
     'name' => 'Australian Government ISM Policy (Weak)',
-    'description' => 'Weak password policy that conforms to Australian Government ISM Control: 0421; Revision: 2; Updated: Sep-12;.',
+    'description' => 'Weak password policy that conforms to Australian Government ISM Control: 0421; Revision: 2; Updated: Jan-22-2019.',
     'enabled' => 1,
     'expiration' => 90,
     'warning' => 7,

--- a/modules/custom/govcms_password_policy/govcms_password_policy.module
+++ b/modules/custom/govcms_password_policy/govcms_password_policy.module
@@ -104,6 +104,7 @@ function govcms_password_policy_get_policies() {
       "alphanumeric" => "1",
       "character_types" => "3",
       "delay" => "24",
+      "digit_placement" => "1",
       "history" => "8",
       "length" => "11",
       "letter" => "1",
@@ -122,6 +123,7 @@ function govcms_password_policy_get_policies() {
     'constraints' => array(
       "alphanumeric" => "1",
       "delay" => "24",
+      "digit_placement" => "1",
       "history" => "8",
       "length" => "15",
       "letter" => "1",


### PR DESCRIPTION
Changes which introduce remediation for SA-Contrib-2018-077 reflected for branch `3.x`, except for `2.x`. These changes were also made in #758 and #768.