### PR TITLE
[GovCMS 7.x-3.x] Drupal core update to 7.64 (from 7.63)

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,5 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.63"
+projects[drupal][version] = "7.64"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
-projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
## https://www.drupal.org/project/drupal/releases/7.64

Release notes
Maintenance release of the Drupal 7 series. Includes bug fixes and small API/feature improvements only (no major, non-backwards-compatible new functionality).

No security fixes are included in this release.

No changes have been made to the .htaccess, web.config, robots.txt in this release, so upgrading custom versions of those files is not necessary.

There is one change to the sites/default/default.settings.php file in this release:

Some directory names are skipped when searching for extensions (module, themes, etc.): https://www.drupal.org/node/3024333.
Major changes since 7.63:
Issue #3018637 by emilymoi, das-peter: [regression] Unset the 'host' header in drupal_http_request() during redirect
Compatibility fixes for PHP 7.3 (#3020771)
Compatibility fixes for MySQL 5.7 (#2981248)
All changes since 7.63:
#1430934 by johnish@gmail.com, DamienMcKenna, Berdir, malcomio, Dane Powell, zerolab, er.pushpinderrana, akosipax, njbarrett, Fabianx, alesr, David_Rothstein, littledynamo, das-peter: Notice: Undefined index: display_field in file_field_widget_value() (line 582 of /module/file/file.field.inc)
#1470656 by Damien Tournoud, joseph.olstad, Pol, Fabianx, catch: Registry rebuild should not parse the same file twice in the same request
#3028364 by Pol, Fabianx: Update function _registry_update() and move module_implements() and _registry_check_code() calls out of the try/catch
#3018637 by emilymoi, das-peter: [regression] Unset the 'host' header in drupal_http_request() during redirect
#3026529 by alexpott: 7.x does not have Phar protection and Phar tests are failing on Drupal 7
#2482549 by Pol, marcelovani, ndf, drupal@guusvandewal.nl, TR, jenlampton, kaidjohnson, ufku, MiSc, David_Rothstein, RobLoach, pablo.guerino, afoster, geerlingguy, SebCorbin, joelpittet, JohnAlbin: Fix up commit - convert short array styles to long.
#3023066 by Pol, mfb: [PHP 7.3] Fix BootstrapMiscTestCase::testCheckMemoryLimit() notice
#2482549 by Pol, marcelovani, ndf, drupal@guusvandewal.nl, jenlampton, ufku, kaidjohnson, MiSc, David_Rothstein, RobLoach, SebCorbin, geerlingguy, pablo.guerino, JohnAlbin, joelpittet, afoster: Ignore node_module folder in core to use Drupal with npm/grunt/nodejs
#3020771 by Ayesh, Pol, sjerdo: [PHP 7.3] strpos explicit string needle warnings
#2981248 by mfb, LFP6, msti: MySQL 5.7 incompatibility in system upgrade 7061

## Patch removed

Patch 'Registry rebuild should not parse the same file twice in the same request' included i 7.64 release hence it is removed.