### PR TITLE
Update solr Dockerfile to be consistent with lagoon image

### DIFF
--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/solr:6.6-drupal
+FROM amazeeio/solr:6.6
 COPY --from=cli /app/profiles/govcms/modules/contrib/search_api_solr/solr-conf/6.x/ /solr-conf/conf/
 
 USER root


### PR DESCRIPTION
This PR will prevent PR test builds from inheriting D8 solr schema.xml on D7.