### PR TITLE
[SA-CORE-2019-006] Update drupal/core to 7.66 (from 7.65)

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,5 +1,5 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.65"
+projects[drupal][version] = "7.66"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch


### PR DESCRIPTION
## https://www.drupal.org/sa-core-2019-006

Project: Drupal core
Date: 2019-April-17
Security risk: Moderately critical 10∕25 AC:Complex/A:Admin/CI:Some/II:Some/E:Theoretical/TD:Uncommon
Vulnerability: Cross Site Scripting
Description: 
The jQuery project released version 3.4.0, and as part of that, disclosed a security vulnerability that affects all prior versions. As described in their release notes:

jQuery 3.4.0 includes a fix for some unintended behavior when using jQuery.extend(true, {}, ...). If an unsanitized source object contained an enumerable __proto__ property, it could extend the native Object.prototype. This fix is included in jQuery 3.4.0, but patch diffs exist to patch previous jQuery versions.

It's possible that this vulnerability is exploitable with some Drupal modules. As a precaution, this Drupal security release backports the fix to jQuery.extend(), without making any other changes to the jQuery version that is included in Drupal core (3.2.1 for Drupal 8 and 1.4.4 for Drupal 7) or running on the site via some other module such as jQuery Update.