### PR TITLE
Remove GMP from the govCMS build.

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -25,8 +25,4 @@ RUN rm -rf /app \
 
 FROM amazeeio/php:7.1-cli-drupal
 
-RUN apk add gmp gmp-dev \
-    && docker-php-ext-install gmp \
-    && docker-php-ext-configure gmp
-
 COPY --from=builder /app /app

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -3,8 +3,4 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/php:7.1-fpm
 
-RUN apk add gmp gmp-dev \
-    && docker-php-ext-install gmp \
-    && docker-php-ext-configure gmp
-
 COPY --from=cli /app /app


### PR DESCRIPTION
GMP is only required for d7 if the openid module is being used.

- Removes GMP from cli image.
- Removes GMP from php image.

![image](https://user-images.githubusercontent.com/1840912/59241621-c827d400-8c4b-11e9-86d3-8f32fa45a1fa.png)
