### PR TITLE
[GOVCMSD7-156] Remove pathauto_persist module

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -104,7 +104,6 @@ projects[paranoia][version] = "1.7"
 projects[password_policy][version] = "1.16"
 projects[pathauto][version] = "1.3"
 ; @TODO remove this after pathauto update.
-projects[pathauto_persist][version] = "1.4"
 projects[pathologic][version] = "3.1"
 projects[pci_update][version] = "1.0"
 projects[pci_update][patch][] = "https://www.drupal.org/files/issues/pci_update_password_field_0.patch"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -103,7 +103,6 @@ projects[paragraphs][patch][] = "https://www.drupal.org/files/issues/paragraphs_
 projects[paranoia][version] = "1.7"
 projects[password_policy][version] = "1.16"
 projects[pathauto][version] = "1.3"
-; @TODO remove this after pathauto update.
 projects[pathologic][version] = "3.1"
 projects[pci_update][version] = "1.0"
 projects[pci_update][patch][] = "https://www.drupal.org/files/issues/pci_update_password_field_0.patch"

--- a/govcms.profile
+++ b/govcms.profile
@@ -68,15 +68,3 @@ function govcms_system_info_alter(&$info, $file, $type) {
     $info['dependencies'] = array();
   }
 }
-
-/**
- * Implements hook_paranoia_hide_modules().
- *
- * @TODO remove this after pathauto update.
- */
-function govcms_paranoia_hide_modules() {
-  return array(
-    'pathauto_persist' => 'Other',
-    'govcms_register' => 'govCMS',
-  );
-}


### PR DESCRIPTION
The module **pathauto_persist** has been merged into the Pathauto module hence no longer required  in the distribution.