### PR TITLE
Fix the element not interactable error for blog-article.feature

### DIFF
--- a/tests/behat/features/content_types/blog-article.feature
+++ b/tests/behat/features/content_types/blog-article.feature
@@ -28,6 +28,7 @@ Feature: Blog Article
     And I submit the media browser
     Then the "#edit-field-thumbnail" element should contain "Edit"
     And the "#edit-field-thumbnail" element should contain "Remove"
+    And I press "Save"
     And I fill in the following:
       | Title   | New blog               |
       | Summary | How we migrated to govCMS! |

--- a/tests/behat/features/content_types/blog-article.feature
+++ b/tests/behat/features/content_types/blog-article.feature
@@ -28,11 +28,9 @@ Feature: Blog Article
     And I submit the media browser
     Then the "#edit-field-thumbnail" element should contain "Edit"
     And the "#edit-field-thumbnail" element should contain "Remove"
-    When I press "Save"
-    Then I should see "autotest.jpg"
-    When I fill in the following:
-      | Title   | New blog               |
-      | Summary | How we migrated to govCMS! |
+    And I press "Save"
+    And I enter "New blog" for "Title"
+    And I put "govCMS is the best!" into WYSIWYG of "Summary" field
     And I put "Digital transformation is real. GovCMS is the best!" into WYSIWYG of "Body" field
     Given I click "Publishing options"
     Then I select "Published" from "Moderation state"

--- a/tests/behat/features/content_types/blog-article.feature
+++ b/tests/behat/features/content_types/blog-article.feature
@@ -28,8 +28,9 @@ Feature: Blog Article
     And I submit the media browser
     Then the "#edit-field-thumbnail" element should contain "Edit"
     And the "#edit-field-thumbnail" element should contain "Remove"
-    And I press "Save"
-    And I fill in the following:
+    When I press "Save"
+    Then I should see "autotest.jpg"
+    When I fill in the following:
       | Title   | New blog               |
       | Summary | How we migrated to govCMS! |
     And I put "Digital transformation is real. GovCMS is the best!" into WYSIWYG of "Body" field


### PR DESCRIPTION
There is Behat error said:
'--- FAIL ---
    And I fill in the following: # (features/content_types/blog-article.feature):31
    | Title   | New blog                   |
| Summary | How we migrated to govCMS! |
      element not interactable
  (Session info: chrome=74.0.3729.169)
  (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.10.0-35-generic x86_64)'

Similar errors occur with following test script:
- features/content_types/blog-article.feature
- features/content_types/event.feature
- features/content_types/media-release.feature
- features/content_types/news-article.feature
- features/content_types/publication.feature
- features/content_types/standard-page.feature