### PR TITLE
[GOVCMSD7-398] Update Dockerfile images to php 7.4 from 7.3

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -1,4 +1,4 @@
-FROM amazeeio/php:7.3-cli-drupal as builder
+FROM uselagoon/php-7.4-cli-drupal as builder
 
 COPY . /src
 
@@ -23,7 +23,7 @@ RUN rm -rf /app \
     } | tee -a "/app/sites/default/settings.php" \
     && chmod 444 /app/sites/default/settings.php
 
-FROM amazeeio/php:7.3-cli-drupal
+FROM uselagoon/php-7.4-cli-drupal
 
 RUN apk add gmp gmp-dev \
     && docker-php-ext-install gmp \

--- a/.docker/Dockerfile.mariadb-drupal
+++ b/.docker/Dockerfile.mariadb-drupal
@@ -1,1 +1,1 @@
-FROM amazeeio/mariadb-drupal
+FROM uselagoon/mariadb-drupal

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -1,5 +1,5 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/nginx-drupal
+FROM uselagoon/nginx-drupal
 COPY --from=cli /app /app

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/php:7.3-fpm
+FROM uselagoon/php-7.4-fpm
 
 RUN apk add gmp gmp-dev \
     && docker-php-ext-install gmp \

--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/solr:6.6
+FROM uselagoon/solr-6.6
 COPY --from=cli /app/profiles/govcms/modules/contrib/search_api_solr/solr-conf/6.x/ /solr-conf/conf/
 
 USER root

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/php:7.3-cli-drupal
+FROM uselagoon/php-7.4-cli-drupal
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
6 files changed to update Dockerfile images in D7 distribution to be same with the changes in govcmslagoon project.
Dockerfile.govcms7
Dockerfile.php
Dockerfile.test
Dockerfile.solr
Dockerfile.nginx-drupal
Dockerfile.mariadb-drupal