### PR TITLE
[GOVCMSD7-421] Update drupal core to 7.82

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.80"
+projects[drupal][version] = "7.82"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2021-01-07/core-use_reply_to_instead_of_from-111702-216.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/reset-flood-2880910-30.patch


### PR DESCRIPTION
# drupal 7.82
## Release notes
Maintenance and security release of the Drupal 7 series.

This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

Drupal core - Critical - Third-party library - SA-CORE-2021-004
No other fixes are included.

Important update information
No changes have been made to the .htaccess, web.config, robots.txt, or default settings.php files in this release, so upgrading custom versions of those files is not necessary if your site is already on the previous release.