### PR TITLE
Release/7.x 3.22

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 core = 7.x
 api = 2
-projects[drupal][version] = "7.80"
+projects[drupal][version] = "7.82"
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2021-01-07/core-use_reply_to_instead_of_from-111702-216.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/reset-flood-2880910-30.patch


### PR DESCRIPTION
Update Drupal core to as advised by Security Advisories https://www.drupal.org/sa-core-2021-004

Security risk: Critical 15∕25 A C:Complex/A:User/CI:All/II:All/E:Theoretical/TD:Uncommon
Vulnerability: Drupal core - Critical - Third-party libraries
CVE IDs:  CVE-2021-32610
Description:  The Drupal project uses the pear Archive_Tar library, which has released a security update that impacts Drupal.

The vulnerability is mitigated by the fact that Drupal core's use of the Archive_Tar library is not vulnerable, as it does not permit symlinks.

Exploitation may be possible if contrib or custom code uses the library to extract tar archives (for example .tar, .tar.gz, .bz2, or .tlz) which come from a potentially untrusted source.

This advisory is not covered by Drupal Steward.
Solution: 
Install the latest version:

If you are using Drupal 7, update to Drupal 7.82.
