### PR TITLE
[GOVCMSD7-451] Upgrade CKEditor Library from 4.17.1 to 4.18.0

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -219,7 +219,7 @@ libraries[html5placeholder][directory_name] = "html5placeholder"
 libraries[html5placeholder][type] = "library"
 
 libraries[ckeditor][download][type] = "get"
-libraries[ckeditor][download][url] = "https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.17.1/ckeditor_4.17.1_full.zip"
+libraries[ckeditor][download][url] = "https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.18.0/ckeditor_4.18.0_full.zip"
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[ckeditor][type] = "library"
 


### PR DESCRIPTION
SA-CORE-2022-005 - Drupal 7 - Upgrade CKEditor Library from 4.17.1 to 4.18.0 - https://www.drupal.org/sa-core-2022-005